### PR TITLE
Simplify deploying to your test subgraph

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Mainnet
+# SUBGRAPH=YourGithubUser/YourSubgraph
+# NETWORK=mainnet
+
+# Rinkeby
+SUBGRAPH=YourGithubUser/YourSubgraph
+NETWORK=rinkeby
+
+# Gnosis Chain
+# SUBGRAPH=YourGithubUser/YourSubgraph
+# NETWORK=gc

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build/
 *.log
 generated/
 node_modules/
+.env

--- a/README.md
+++ b/README.md
@@ -37,40 +37,33 @@ Notice order entity has 3 different timestamps. Each timestamp will be filled de
 
 *Requisites:* You must have access to a console and have yarn installed. More info about [yarn](https://classic.yarnpkg.com/lang/en/docs/)
 
-1.- Clone this repo
-```
-git clone git@github.com:gnosis/cow-subgraph.git
-```
+1. Install the dependencies by executing:
 
-2.- Install the dependencies by executing:
-
-```
+```bash
 $ yarn
 ```
 
-3.- Go to The Graph [hosted service](https://thegraph.com/hosted-service/dashboard) and log in using your github credentials. 
+2. Go to The Graph [hosted service](https://thegraph.com/hosted-service/dashboard) and log in using your github credentials. 
 
-4.- Copy your access token and run the following
+3. Copy your access token and run the following:
 
-```
+```bash
 $ graph auth --product hosted-service <YourAccessToken>
 ```
 
-5.- Using your browser create a new subgraph in the dashboard by clicking "Add Subgraph" button and complete the form. Notice your subgraph will be named as the following: "YourGithubAccount/SubgraphName"
+5. In your browser, create a new subgraph in the dashboard by clicking "Add Subgraph" button. Complete the form. Notice your subgraph will be named: `YourGithubAccount/SubgraphName`
 
-6.- Edit the package.json file using your favorite editor. Replace <YourGithubUser/YourSubgraph> with the value obtained in the previous step. Replace <Network> field too with the desired network you want to deploy, ```mainnet``` for ethereum mainnet, ```rinkeby``` for ethereum rinkeby or ```gc``` for gnosis chain. (Remove the "<" and the ">" characters)
+6. Create your own environment and edit so it points to your testing subgraph:
 
-7.- Execute the following commands:
+```bash
+cp .env.example .env
 ```
-$ yarn deploy:dev
+
+7. Deploy:
+```bash
+yarn deploy
 ```
 
 If everything went well you'll have a copy of this subgraph running on your hosted service account indexing your desired network.
 
-Please notice a subgraph can only index a single network, if you want to index another network you should create a new sugraph and do same steps starting from step 3.
-
----------
-
-If you have any suggestion about this work feel free to create a task or a pull request with your own changes to be considered. 
-
-Mooooh!
+Please notice a subgraph can only index a single network, if you want to index another network you should create a new subgraph and do same steps starting from step 3.

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "devDependencies": {
     "chalk": "^2.4.1",
-    "cross-env": "^7.0.3"
+    "cross-env": "^7.0.3",
+    "dotenv": "^16.0.0"
   }
 }

--- a/src/scripts/deploy.js
+++ b/src/scripts/deploy.js
@@ -1,8 +1,10 @@
-const assert = require('assert');
-const {series} = require('async');
-const { default: chalk } = require('chalk');
-const {exec} = require('child_process');
+const assert = require('assert')
+const {series} = require('async')
+const { default: chalk } = require('chalk')
+const {exec} = require('child_process')
 const {confirm} = require('./utils')
+
+require('dotenv').config()
 
 const NETWORK = process.env.NETWORK
 assert(NETWORK, 'NETWORK env var is required')

--- a/src/scripts/prepare.js
+++ b/src/scripts/prepare.js
@@ -1,6 +1,8 @@
-const assert = require('assert');
+const assert = require('assert')
 const {series} = require('async')
-const {exec} = require('child_process');
+const {exec} = require('child_process')
+
+require('dotenv').config()
 
 // const DEV_SUBGRAPH = process.env.DEV_SUBGRAPH
 // assert(DEV_SUBGRAPH, 'DEV_SUBGRAPH env var is required')

--- a/yarn.lock
+++ b/yarn.lock
@@ -797,6 +797,11 @@ dockerode@^2.5.8:
     docker-modem "^1.0.8"
     tar-fs "~1.16.3"
 
+dotenv@^16.0.0:
+  version "16.0.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.0.0.tgz#c619001253be89ebb638d027b609c75c26e47411"
+  integrity sha512-qD9WU0MPM4SWLPJy/r2Be+2WgQj8plChsyrCNQzW/0WjvcJQiKQJ9mH3ZgB3fxbUUxgc/11ZJ0Fi5KiimWGz2Q==
+
 drbg.js@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/drbg.js/-/drbg.js-1.0.1.tgz#3e36b6c42b37043823cdbc332d58f31e2445480b"


### PR DESCRIPTION
This PR allows to setup in your local config your test subgraph.

This way, you can deploy there in a simple way.
The README has been updated accordinly.


<img width="783" alt="image" src="https://user-images.githubusercontent.com/2352112/161608588-32f1dcd2-9905-4836-957f-5526307e7f94.png">
