### PR TITLE
Hotfix to prevent error when indexing

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -4,7 +4,7 @@ type User @entity {
   "Owner's address"
   address: Bytes!
   "First trade block timestamp"
-  firstTradeTimestamp: Int
+  firstTradeTimestamp: Int!
   "List of orders placed by this user"
   ordersPlaced: [Order!]! @derivedFrom(field: "owner")
   "Determine if user has solved a settlement"
@@ -27,7 +27,7 @@ type Token @entity {
   "Token address"
   address: Bytes!
   "First token trade block timestamp"
-  firstTradeTimestamp: Int
+  firstTradeTimestamp: Int!
   "Token name fetched by ERC20 contract call"
   name: String!
   "Token symbol fetched by contract call"

--- a/src/modules/tokens.ts
+++ b/src/modules/tokens.ts
@@ -20,7 +20,7 @@ export namespace tokens {
       // creates a new token and fill properites
       token = new Token(tokenId)
       token.address = tokenAddress
-      token.firstTradeTimestamp = timestamp
+      token.firstTradeTimestamp = timestamp ? timestamp : 0;
 
       // try contract calls for filling decimals, name and symbol
       let erc20Token = ERC20.bind(tokenAddress)

--- a/src/modules/users.ts
+++ b/src/modules/users.ts
@@ -16,6 +16,7 @@ export namespace users {
             user.solvedAmountUsd = ZERO_BD
             user.tradedAmountEth = ZERO_BD
             user.tradedAmountUsd = ZERO_BD
+            user.firstTradeTimestamp = 0
         } 
 
         return user as User


### PR DESCRIPTION
This is the error
```{"data":{"indexingStatusForPendingVersion":{"subgraph":"QmQHHUMcek6GPbCx6ENCeSWJQycb13Xur4KE3GXu9XqcyT","fatalError":{"message":"Mapping aborted at ~lib/@graphprotocol/graph-ts/index.ts, line 801, column 4, with message: Value is not an i32.\twasm backtrace:\t    0: 0x2faa - <unknown>!~lib/@graphprotocol/graph-ts/index/Value#toI32\t    1: 0x3479 - <unknown>!generated/schema/Token#get:firstTradeTimestamp\t    2: 0x404b - <unknown>!src/modules/users/users.getOrCreateTrader\t    3: 0x4e58 - <unknown>!src/modules/trades/trades.getOrCreateTrade\t    4: 0x5169 - <unknown>!src/mapping/handleTrade\t in handler `handleTrade` at block #12959355 (918f5cbad17ce2eb96da3b92f488852fc36d5d2f22e192ea22fcd58b47e8bebd)"},"nonFatalErrors":[]}}}%```

On this error "Value is not an i32" there are 2 things that took my attention:

1.- `generated/schema/Token#get:firstTradeTimestamp` the error seems to be at token.firstTradeTimestamp

2.- `src/modules/users/users.getOrCreateTrader`it's failing here.

I can't tell how getOrCreateTrader is using the token.firstTradeTimestamp. so that stack doesn't make sense to me. I wanted to solve it as fast as I can, that's why I removed the nullabitilty form both entities, user and token in firstTradeTimestamp property.