### PR TITLE
Adding and removing a prop on settlement entity - Fixed timestamps on pair totals entity that was wrong

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -117,8 +117,6 @@ type Settlement @entity {
   txHash: Bytes!
   "Block number"
   blockNumber: BigInt!
-  "First trade timestamp"
-  firstTradeTimestamp: Int!
   "Collection of trades"
   trades: [Trade!] @derivedFrom(field: "settlement")
   "User who solved the settlement"

--- a/schema.graphql
+++ b/schema.graphql
@@ -115,6 +115,8 @@ type Settlement @entity {
   id: ID!
   "Transaction hash"
   txHash: Bytes!
+  "Block number"
+  blockNumber: BigInt!
   "First trade timestamp"
   firstTradeTimestamp: Int!
   "Collection of trades"

--- a/schema.graphql
+++ b/schema.graphql
@@ -117,6 +117,8 @@ type Settlement @entity {
   txHash: Bytes!
   "Block number"
   blockNumber: BigInt!
+  "First trade timestamp"
+  firstTradeTimestamp: Int!
   "Collection of trades"
   trades: [Trade!] @derivedFrom(field: "settlement")
   "User who solved the settlement"

--- a/src/modules/pairs.ts
+++ b/src/modules/pairs.ts
@@ -166,7 +166,7 @@ export namespace pairs {
       pairDailyTotal = new PairDaily(id)
       pairDailyTotal.token0 = token0
       pairDailyTotal.token1 = token1
-      pairDailyTotal.timestamp = timestamp
+      pairDailyTotal.timestamp = dailyTimestamp
       pairDailyTotal.volumeToken0 = ZERO_BI
       pairDailyTotal.volumeToken1 = ZERO_BI
       pairDailyTotal.volumeTradedEth = ZERO_BD
@@ -186,7 +186,7 @@ export namespace pairs {
       pairHourlyTotal = new PairHourly(id)
       pairHourlyTotal.token0 = token0
       pairHourlyTotal.token1 = token1
-      pairHourlyTotal.timestamp = timestamp
+      pairHourlyTotal.timestamp = hourlyTimestamp
       pairHourlyTotal.volumeToken0 = ZERO_BI
       pairHourlyTotal.volumeToken1 = ZERO_BI
       pairHourlyTotal.volumeTradedEth = ZERO_BD

--- a/src/modules/settlements.ts
+++ b/src/modules/settlements.ts
@@ -29,7 +29,6 @@ export namespace settlements {
             settlement = new Settlement(settlementId)
             settlement.txHash = txHash
             settlement.blockNumber = blockNumber
-            settlement.firstTradeTimestamp = tradeTimestamp
             settlement.solver = solver.toHexString()
             settlement.txCostUsd = txCostUsd
             settlement.txCostNative = txCostNative

--- a/src/modules/settlements.ts
+++ b/src/modules/settlements.ts
@@ -7,7 +7,7 @@ import { getEthPriceInUSD } from "../utils/pricing"
 
 export namespace settlements {
 
-    export function getOrCreateSettlement(blockNumber: BigInt, txHash: Bytes, tradeTimestamp: i32, solver: Address, txGasPrice: BigInt, feeAmountUsd: BigDecimal): void { 
+    export function getOrCreateSettlement(blockNumber: BigInt, txHash: Bytes, tradeTimestamp: i32, solver: Address, txGasPrice: BigInt, feeAmountUsd: BigDecimal | null): void { 
 
         let settlementId = txHash.toHexString()
         let network = dataSource.network()

--- a/src/modules/settlements.ts
+++ b/src/modules/settlements.ts
@@ -7,7 +7,7 @@ import { getEthPriceInUSD } from "../utils/pricing"
 
 export namespace settlements {
 
-    export function getOrCreateSettlement(txHash: Bytes, tradeTimestamp: i32, solver: Address, txGasPrice: BigInt, feeAmountUsd: BigDecimal): void { 
+    export function getOrCreateSettlement(blockNumber: BigInt, txHash: Bytes, tradeTimestamp: i32, solver: Address, txGasPrice: BigInt, feeAmountUsd: BigDecimal): void { 
 
         let settlementId = txHash.toHexString()
         let network = dataSource.network()
@@ -28,6 +28,7 @@ export namespace settlements {
         if (!settlement) {
             settlement = new Settlement(settlementId)
             settlement.txHash = txHash
+            settlement.blockNumber = blockNumber
             settlement.firstTradeTimestamp = tradeTimestamp
             settlement.solver = solver.toHexString()
             settlement.txCostUsd = txCostUsd

--- a/src/modules/settlements.ts
+++ b/src/modules/settlements.ts
@@ -29,6 +29,7 @@ export namespace settlements {
             settlement = new Settlement(settlementId)
             settlement.txHash = txHash
             settlement.blockNumber = blockNumber
+            settlement.firstTradeTimestamp = tradeTimestamp
             settlement.solver = solver.toHexString()
             settlement.txCostUsd = txCostUsd
             settlement.txCostNative = txCostNative

--- a/src/modules/trades.ts
+++ b/src/modules/trades.ts
@@ -21,6 +21,7 @@ export namespace trades {
         let solver = event.transaction.from
         let ownerAddress = event.params.owner
         let owner = ownerAddress.toHexString()
+        let blockNumber = event.block.number
 
         let buyAmountDecimals = convertTokenToDecimal(buyAmount, BigInt.fromI32(buyToken.decimals))
         let buyAmountUsd = buyToken.priceUsd.times(buyAmountDecimals)
@@ -34,7 +35,7 @@ export namespace trades {
         let feeAmountEth = sellToken.priceEth.times(feeAmountDecimals)
 
         // This statement need to be after tokens prices calculation.
-        settlements.getOrCreateSettlement(txHash, timestamp, solver, txGasPrice, feeAmountUsd)
+        settlements.getOrCreateSettlement(blockNumber, txHash, timestamp, solver, txGasPrice, feeAmountUsd)
 
         let trade = TradeEntity.load(tradeId)
 


### PR DESCRIPTION
Fixed value on daily and hourly pairs of timestamp that was reported wrong. The timestamp was wrong because on pairDailyTotal, it was using directly the timestamp from the block instead of using the conversion for the daily infomation. 
We changed that for pairDailyTotals entity and pairHourlyTotals entity because it was wrong in both of them.

On Settlement entitiy there was created a new prop called blockNumber to show the block where the settle was created. It was removed the firstTradeTimestamp because it's a prop that belongs to a trade and can be consumed form there.

Closes #50 
Closes #51

Deployed and indexing here:
https://thegraph.com/hosted-service/subgraph/gabrielcamba/cow-two