### PR TITLE
Fixed errors when indexing

### DIFF
--- a/src/modules/settlements.ts
+++ b/src/modules/settlements.ts
@@ -7,7 +7,7 @@ import { getEthPriceInUSD } from "../utils/pricing"
 
 export namespace settlements {
 
-    export function getOrCreateSettlement(txHash: Bytes, tradeTimestamp: i32, solver: Address, txGasPrice: BigInt, feeAmountUsd: BigDecimal): void { 
+    export function getOrCreateSettlement(txHash: Bytes, tradeTimestamp: i32, solver: Address, txGasPrice: BigInt, feeAmountUsd: BigDecimal | null): void { 
 
         let settlementId = txHash.toHexString()
         let network = dataSource.network()
@@ -36,8 +36,10 @@ export namespace settlements {
             settlement.profitability = ZERO_BD
             totals.addSettlementCount(tradeTimestamp)
         } 
-        let prevFeeAmountUsd = settlement.aggregatedFeeAmountUsd
-        settlement.aggregatedFeeAmountUsd = prevFeeAmountUsd.plus(feeAmountUsd)
+        if(feeAmountUsd) {
+            let prevFeeAmountUsd = settlement.aggregatedFeeAmountUsd
+            settlement.aggregatedFeeAmountUsd = prevFeeAmountUsd.plus(feeAmountUsd)
+        }
         settlement.profitability = settlement.aggregatedFeeAmountUsd.minus(settlement.txCostUsd)
         settlement.save()
     }

--- a/src/modules/trades.ts
+++ b/src/modules/trades.ts
@@ -53,8 +53,8 @@ export namespace trades {
         let buyTokenId = buyToken.id
         let sellTokenId = sellToken.id
 
-        let buyTokenPriceUsd = buyToken.priceUsd as BigDecimal
-        let sellTokenPriceUsd = sellToken.priceUsd as BigDecimal
+        let buyTokenPriceUsd = _buyTokenPriceUsd ? _buyTokenPriceUsd as BigDecimal : null
+        let sellTokenPriceUsd = _sellTokenPriceUsd ? _sellTokenPriceUsd as BigDecimal : null
 
         tokens.createTokenTradingEvent(timestamp, buyTokenId, tradeId, buyAmount, buyAmountEth, buyAmountUsd, buyTokenPriceUsd)
         tokens.createTokenTradingEvent(timestamp, sellTokenId, tradeId, sellAmount, sellAmountEth, sellAmountUsd, sellTokenPriceUsd)

--- a/src/utils/getPrices.ts
+++ b/src/utils/getPrices.ts
@@ -44,9 +44,9 @@ function getUniswapPricesForPair(token0: Address, token1: Address, isEthPriceCal
     let reservesTry = pair.try_getReserves()
     let reserves = reservesTry.reverted ? EMPTY_RESERVES_RESULT : reservesTry.value
     let pairToken0Try = pair.try_token0()
-    let pairToken0 = pairToken0Try.reverted ? ZERO_ADDRESS as Address : pairToken0Try.value
+    let pairToken0 = pairToken0Try.reverted ? changetype<Address>(ZERO_ADDRESS) : pairToken0Try.value
     let pairToken1Try = pair.try_token1()
-    let pairToken1 = pairToken1Try.reverted ? ZERO_ADDRESS as Address : pairToken1Try.value
+    let pairToken1 = pairToken1Try.reverted ? changetype<Address>(ZERO_ADDRESS) : pairToken1Try.value
 
     if (reserves.value0 == ZERO_BI ||
         reserves.value1 == ZERO_BI ||


### PR DESCRIPTION
After merging graph-cli and graph-ts upgrade (https://github.com/cowprotocol/subgraph/pull/42) some errors related to change the version appeared.
This PR is to fix those errors.

Errors:
- Casting nullable values throws an error. 
   - Example: price as BigDecimal :x: 
   - Fix: price ? price as BigDecimal : null :heavy_check_mark: 
   
- Upcast was not allowed using as:
   - Example: ZERO_ADDRESS as Address :x:
   - Fix: changetype<Address>(ZERO_ADDRESS) :heavy_check_mark: 
   
- on function getOrCreateSettlement feeAmountUsd property can be null. 
  - handled null value in the function parameter and checked with an if statement before using that value.

All errors were fixed based on the docs (https://thegraph.com/docs/en/release-notes/assemblyscript-migration-guide) and discord comments (https://discord.com/channels/438038660412342282/438070183794573313)
 
Currenlty indexing: 
Mainnet: https://thegraph.com/hosted-service/subgraph/cowprotocol/cow-staging
GC: https://thegraph.com/hosted-service/subgraph/cowprotocol/cow-gc-staging