### PR TITLE
Changed type on Pairs entities property volumeToken[x]

### DIFF
--- a/model.md
+++ b/model.md
@@ -189,8 +189,8 @@ class Pair {
   token1Price: BigDecimal
   token0relativePrice: BigDecimal
   token1relativePrice: BigDecimal
-  volumeToken0: BigInt
-  volumeToken1: BigInt
+  volumeToken0: BigDecimal!
+  volumeToken1: BigDecimal!
   volumeTradedEth: BigDecimal
   volumeTradedUsd: BigDecimal
 }
@@ -207,8 +207,8 @@ class PairDaily {
   token0relativePrice: BigDecimal
   token1relativePrice: BigDecimal
   timestamp: BigInt
-  volumeToken0: BigInt
-  volumeToken1: BigInt
+  volumeToken0: BigDecimal!
+  volumeToken1: BigDecimal!
   volumeTradedEth: BigDecimal
   volumeTradedUsd: BigDecimal
 }
@@ -225,8 +225,8 @@ class PairHourly {
   token0relativePrice: BigDecimal
   token1relativePrice: BigDecimal
   timestamp: BigInt
-  volumeToken0: BigInt
-  volumeToken1: BigInt
+  volumeToken0: BigDecimal!
+  volumeToken1: BigDecimal!
   volumeTradedEth: BigDecimal
   volumeTradedUsd: BigDecimal
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -343,9 +343,9 @@ type Pair @entity {
   "Token 1 price expressed in token1 in the last trade"
   token1PriceInToken0: BigDecimal
   "Total volume of token 0 traded"
-  volumeToken0: BigInt!
+  volumeToken0: BigDecimal!
   "Total volume of token 1 traded"
-  volumeToken1: BigInt!
+  volumeToken1: BigDecimal!
   "Total volume in Eth"
   volumeTradedEth: BigDecimal
   "Total volume in Usd"
@@ -370,9 +370,9 @@ type PairDaily @entity {
   "Start day timestamp"
   timestamp: Int!
   "Total volume of token 0 traded"
-  volumeToken0: BigInt!
+  volumeToken0: BigDecimal!
   "Total volume of token 1 traded"
-  volumeToken1: BigInt!
+  volumeToken1: BigDecimal!
   "Total volume in Eth"
   volumeTradedEth: BigDecimal
   "Total volume in Usd"
@@ -397,9 +397,9 @@ type PairHourly @entity {
   "Start hour timestamp"
   timestamp: Int!
   "Total volume of token 0 traded"
-  volumeToken0: BigInt!
+  volumeToken0: BigDecimal!
   "Total volume of token 1 traded"
-  volumeToken1: BigInt!
+  volumeToken1: BigDecimal!
   "Total volume in Eth"
   volumeTradedEth: BigDecimal
   "Total volume in Usd"

--- a/src/modules/pairs.ts
+++ b/src/modules/pairs.ts
@@ -7,12 +7,12 @@ export namespace pairs {
 
   export class TokenProps {
     token: string
-    volume: BigInt
+    volume: BigDecimal
     price: BigDecimal | null
     relativePrice: BigDecimal
     constructor(
       _token: string,
-      _volume: BigInt,
+      _volume: BigDecimal,
       _price: BigDecimal | null,
       _relativePrice: BigDecimal
     ) {
@@ -23,10 +23,10 @@ export namespace pairs {
     }
   }
 
-  export function createOrUpdatePair(timestamp: i32, buyTokenId: string, sellTokenId: string, buyAmount: BigInt, sellAmount: BigInt,
+  export function createOrUpdatePair(timestamp: i32, buyTokenId: string, sellTokenId: string, 
     sellAmountEth: BigDecimal | null, sellAmountUsd: BigDecimal | null, buyTokenPriceUsd: BigDecimal | null, sellTokenPriceUsd: BigDecimal | null,
     buyAmountDecimals: BigDecimal, sellAmountDecimals: BigDecimal): void {
-    let canonicalMarket = getCanonicalMarket(buyTokenId, sellTokenId, buyAmount, sellAmount, buyTokenPriceUsd, sellTokenPriceUsd, buyAmountDecimals, sellAmountDecimals)
+    let canonicalMarket = getCanonicalMarket(buyTokenId, sellTokenId, buyTokenPriceUsd, sellTokenPriceUsd, buyAmountDecimals, sellAmountDecimals)
 
     let token0Props = canonicalMarket.get("token0")
     let token0 = token0Props.token
@@ -50,7 +50,7 @@ export namespace pairs {
       sellAmountEth, sellAmountUsd)
   }
 
-  function getCanonicalMarket(buyTokenId: string, sellTokenId: string, buyAmount: BigInt, sellAmount: BigInt,
+  function getCanonicalMarket(buyTokenId: string, sellTokenId: string, 
     buyTokenPriceUsd: BigDecimal | null, sellTokenPriceUsd: BigDecimal | null,
     buyAmountDecimals: BigDecimal, sellAmountDecimals: BigDecimal): Map<string, TokenProps> {
     let buyTokenAddress = Address.fromString(buyTokenId)
@@ -70,8 +70,8 @@ export namespace pairs {
       sellTokenExpressedOnBuyToken = sellAmountDecimals.div(buyAmountDecimals)
     }
 
-    let buyTokenProps = new TokenProps(buyTokenId, buyAmount, buyTokenPriceUsd, buyTokenExpressedOnSellToken)
-    let sellTokenProps = new TokenProps(sellTokenId, sellAmount, sellTokenPriceUsd, sellTokenExpressedOnBuyToken)
+    let buyTokenProps = new TokenProps(buyTokenId, buyAmountDecimals, buyTokenPriceUsd, buyTokenExpressedOnSellToken)
+    let sellTokenProps = new TokenProps(sellTokenId, sellAmountDecimals, sellTokenPriceUsd, sellTokenExpressedOnBuyToken)
 
     if (buyTokenNumber.lt(sellTokenNumber)) {
       value.set("token0", buyTokenProps)
@@ -84,7 +84,7 @@ export namespace pairs {
     return value
   }
 
-  function totalsUpdate(timestamp: i32, pair: Pair, pairDaily: PairDaily, pairHourly: PairHourly, volumeToken0: BigInt, volumeToken1: BigInt,
+  function totalsUpdate(timestamp: i32, pair: Pair, pairDaily: PairDaily, pairHourly: PairHourly, volumeToken0: BigDecimal, volumeToken1: BigDecimal,
     priceToken0: BigDecimal | null, priceToken1: BigDecimal | null, token0RelativePrice: BigDecimal, token1RelativePrice: BigDecimal,
     sellAmountEth: BigDecimal | null, sellAmountUsd: BigDecimal | null): void {
 
@@ -152,8 +152,8 @@ export namespace pairs {
       pairTotal = new Pair(id)
       pairTotal.token0 = token0
       pairTotal.token1 = token1
-      pairTotal.volumeToken0 = ZERO_BI
-      pairTotal.volumeToken1 = ZERO_BI
+      pairTotal.volumeToken0 = ZERO_BD
+      pairTotal.volumeToken1 = ZERO_BD
       pairTotal.volumeTradedEth = ZERO_BD
       pairTotal.volumeTradedUsd = ZERO_BD
     }
@@ -171,8 +171,8 @@ export namespace pairs {
       pairDailyTotal.token0 = token0
       pairDailyTotal.token1 = token1
       pairDailyTotal.timestamp = timestamp
-      pairDailyTotal.volumeToken0 = ZERO_BI
-      pairDailyTotal.volumeToken1 = ZERO_BI
+      pairDailyTotal.volumeToken0 = ZERO_BD
+      pairDailyTotal.volumeToken1 = ZERO_BD
       pairDailyTotal.volumeTradedEth = ZERO_BD
       pairDailyTotal.volumeTradedUsd = ZERO_BD
     }
@@ -191,8 +191,8 @@ export namespace pairs {
       pairHourlyTotal.token0 = token0
       pairHourlyTotal.token1 = token1
       pairHourlyTotal.timestamp = timestamp
-      pairHourlyTotal.volumeToken0 = ZERO_BI
-      pairHourlyTotal.volumeToken1 = ZERO_BI
+      pairHourlyTotal.volumeToken0 = ZERO_BD
+      pairHourlyTotal.volumeToken1 = ZERO_BD
       pairHourlyTotal.volumeTradedEth = ZERO_BD
       pairHourlyTotal.volumeTradedUsd = ZERO_BD
     }

--- a/src/modules/settlements.ts
+++ b/src/modules/settlements.ts
@@ -7,7 +7,7 @@ import { getEthPriceInUSD } from "../utils/pricing"
 
 export namespace settlements {
 
-    export function getOrCreateSettlement(txHash: Bytes, tradeTimestamp: i32, solver: Address, txGasPrice: BigInt, feeAmountUsd: BigDecimal): void { 
+    export function getOrCreateSettlement(txHash: Bytes, tradeTimestamp: i32, solver: Address, txGasPrice: BigInt, feeAmountUsd: BigDecimal | null): void { 
 
         let settlementId = txHash.toHexString()
         let network = dataSource.network()
@@ -36,8 +36,10 @@ export namespace settlements {
             settlement.profitability = ZERO_BD
             totals.addSettlementCount(tradeTimestamp)
         } 
-        let prevFeeAmountUsd = settlement.aggregatedFeeAmountUsd
-        settlement.aggregatedFeeAmountUsd = prevFeeAmountUsd.plus(feeAmountUsd)
+        if(feeAmountUsd) {
+            let prevFeeAmountUsd = settlement.aggregatedFeeAmountUsd
+            settlement.aggregatedFeeAmountUsd = prevFeeAmountUsd.plus(feeAmountUsd)
+        }
         settlement.profitability = settlement.aggregatedFeeAmountUsd.minus(settlement.txCostUsd)
         settlement.save()
     }

--- a/src/modules/trades.ts
+++ b/src/modules/trades.ts
@@ -53,8 +53,8 @@ export namespace trades {
         let buyTokenId = buyToken.id
         let sellTokenId = sellToken.id
 
-        let buyTokenPriceUsd = buyToken.priceUsd as BigDecimal
-        let sellTokenPriceUsd = sellToken.priceUsd as BigDecimal
+        let buyTokenPriceUsd = _buyTokenPriceUsd ? _buyTokenPriceUsd as BigDecimal : null
+        let sellTokenPriceUsd = _sellTokenPriceUsd ? _sellTokenPriceUsd as BigDecimal : null
 
         tokens.createTokenTradingEvent(timestamp, buyTokenId, tradeId, buyAmount, buyAmountEth, buyAmountUsd, buyTokenPriceUsd)
         tokens.createTokenTradingEvent(timestamp, sellTokenId, tradeId, sellAmount, sellAmountEth, sellAmountUsd, sellTokenPriceUsd)

--- a/src/modules/trades.ts
+++ b/src/modules/trades.ts
@@ -92,7 +92,7 @@ export namespace trades {
 
         totals.addVolumesAndFees(ethAmountForVolumes, usdAmountForVolumes, feeAmountEth, feeAmountUsd, timestamp)
 
-        pairs.createOrUpdatePair(timestamp, buyTokenId, sellTokenId, buyAmount, sellAmount, 
+        pairs.createOrUpdatePair(timestamp, buyTokenId, sellTokenId, 
             sellAmountEth, sellAmountUsd, buyTokenPriceUsd, sellTokenPriceUsd, buyAmountDecimals, sellAmountDecimals)
     }
 

--- a/src/utils/getPrices.ts
+++ b/src/utils/getPrices.ts
@@ -44,9 +44,9 @@ function getUniswapPricesForPair(token0: Address, token1: Address, isEthPriceCal
     let reservesTry = pair.try_getReserves()
     let reserves = reservesTry.reverted ? EMPTY_RESERVES_RESULT : reservesTry.value
     let pairToken0Try = pair.try_token0()
-    let pairToken0 = pairToken0Try.reverted ? ZERO_ADDRESS as Address : pairToken0Try.value
+    let pairToken0 = pairToken0Try.reverted ? changetype<Address>(ZERO_ADDRESS) : pairToken0Try.value
     let pairToken1Try = pair.try_token1()
-    let pairToken1 = pairToken1Try.reverted ? ZERO_ADDRESS as Address : pairToken1Try.value
+    let pairToken1 = pairToken1Try.reverted ? changetype<Address>(ZERO_ADDRESS) : pairToken1Try.value
 
     if (reserves.value0 == ZERO_BI ||
         reserves.value1 == ZERO_BI ||


### PR DESCRIPTION
Close #61 

On entities Pair, PairHourly and PairDaily the properties volumeToken0 and volumeToken1 was expressed in BigInt with each volume calculated in atoms. That type made difficult to compare volumes and have a better idea of the volume traded.

volumeToken0 and volumeToken1 is now expressed in BigDecimal making the calculation of the decimals using each token decimals property.

Example query:
```GRAPHQL
{
  pairHourly(id:"0x4ecaba5870353805a9f068101a40e0f32ed605c6-0x6a023ccd1ff6f2045c3309768ead9e68f978f6e1-1628812800"){
    token0{
      symbol
    }
    volumeToken0
  }
}
```
Previous version result:
```JSON
{
  "data": {
    "pairHourly": {
      "token0": {
        "symbol": "USDT"
      },
      "volumeToken0": "109547611"
    }
  }
}
```
New version result:
```JSON
{
  "data": {
    "pairHourly": {
      "token0": {
        "symbol": "USDT"
      },
      "volumeToken0": "109.547611"
    }
  }
}
```
- [Model](https://github.com/cowprotocol/subgraph/blob/dce451ceadcbb904067ec0e612d88ce057fc5a1d/model.md) was fixed to show this change. 

### To test:
For testing this is deployed both on [Ethereum mainnet](https://thegraph.com/hosted-service/subgraph/gabrielcamba/cow-one?version=pending) and [Gnosis chain](https://thegraph.com/hosted-service/subgraph/gabrielcamba/cow-two)

Here is an example query that should work for Pairs, PairsDailies and PairsHourlies entities:

``` GraphQL 
{
  pairDailies(first: 5){
    token0{
      address
      symbol
    }
    token1 {
      address
      symbol
    }
    volumeToken0
    volumeToken1
  }
}
```
The expected result is to have volumes of the tokens expressed with decimals, based on each token definition