### PR TITLE
Performance improvements

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -1,6 +1,6 @@
 type User @entity {
   "Trade event order owner"
-  id: ID!
+  id: Bytes!
   "Owner's address"
   address: Bytes!
   "First trade block timestamp"
@@ -23,7 +23,7 @@ type User @entity {
 
 type Token @entity {
   "Token address to hexString"
-  id: ID!
+  id: Bytes!
   "Token address"
   address: Bytes!
   "First token trade block timestamp"
@@ -56,7 +56,7 @@ type Token @entity {
 
 type Order @entity {
   "Trade's OrderUid to hex string"
-  id: ID!
+  id: Bytes!
   "Trade's owner or presign User"
   owner: User
   "block's timestamp on trade event"
@@ -73,7 +73,7 @@ type Order @entity {
   isValid: Boolean
 }
 
-type Trade @entity {
+type Trade @entity(immutable: true) {
   "This Id is composed using orderId|txHashString|eventIndex"
   id: ID!
   "Block's timestamp"
@@ -110,7 +110,7 @@ type Trade @entity {
   sellAmountUsd: BigDecimal
 }
 
-type Settlement @entity {
+type Settlement @entity(immutable: true) {
   "TxHash"
   id: ID!
   "Transaction hash"
@@ -141,7 +141,7 @@ type Bundle @entity {
 
 type UniswapPool @entity {
   "Pool address"
-  id: ID!
+  id: Bytes!
   "Token0"
   token0: UniswapToken!
   "Token1"
@@ -162,7 +162,7 @@ type UniswapPool @entity {
 
 type UniswapToken @entity {
   "Token address to hexString"
-  id: ID!
+  id: Bytes!
   "Token address"
   address: Bytes!
   "Token name fetched by ERC20 contract call"
@@ -310,7 +310,7 @@ type TokenHourlyTotal @entity {
   averagePrice: BigDecimal!
 }
 
-type TokenTradingEvent @entity {
+type TokenTradingEvent @entity(immutable: true) {
   "Id built using token-timestamp"
   id: ID!
   "Token"

--- a/src/mapping.ts
+++ b/src/mapping.ts
@@ -16,7 +16,7 @@ export function handleInteraction(event: Interaction): void { }
 
 export function handleOrderInvalidated(event: OrderInvalidated): void {
 
-  let orderId = event.params.orderUid.toHexString()
+  let orderId = event.params.orderUid
   let timestamp = event.block.timestamp.toI32()
 
   let order = orders.invalidateOrder(orderId, timestamp)
@@ -26,26 +26,24 @@ export function handleOrderInvalidated(event: OrderInvalidated): void {
 
 export function handlePreSignature(event: PreSignature): void {
 
-  let orderUid = event.params.orderUid.toHexString()
+  let orderUid = event.params.orderUid
   let ownerAddress = event.params.owner
-  let owner = ownerAddress.toHexString()
   let timestamp = event.block.timestamp.toI32()
   let signed = event.params.signed
 
-  let order = orders.setPresignature(orderUid, owner, timestamp, signed)
+  let order = orders.setPresignature(orderUid, ownerAddress, timestamp, signed)
 
   order.save()
 
-  users.getOrCreateSigner(owner, ownerAddress)
+  users.getOrCreateSigner(ownerAddress)
 }
 
 export function handleSettlement(event: Settlement): void { }
 
 
 export function handleTrade(event: Trade): void {
-  let orderId = event.params.orderUid.toHexString()
+  let orderId = event.params.orderUid
   let ownerAddress = event.params.owner
-  let owner = ownerAddress.toHexString()
   let sellTokenAddress = event.params.sellToken
   let buyTokenAddress = event.params.buyToken
   let sellAmount = event.params.sellAmount
@@ -77,8 +75,8 @@ export function handleTrade(event: Trade): void {
       buyToken.priceEth = buyTokenPrices.get("eth")
     }
   } else {
-    let sellUniToken = UniswapToken.load(sellTokenAddress.toHexString())
-    let buyUniToken = UniswapToken.load(buyTokenAddress.toHexString())
+    let sellUniToken = UniswapToken.load(sellTokenAddress)
+    let buyUniToken = UniswapToken.load(buyTokenAddress)
     if (sellUniToken) {
       sellToken.priceUsd = sellUniToken.priceUsd ? sellUniToken.priceUsd : null
       sellToken.priceEth = sellUniToken.priceEth ? sellUniToken.priceEth : null
@@ -131,7 +129,7 @@ export function handleTrade(event: Trade): void {
   sellToken.save()
   buyToken.save()
 
-  let order = orders.getOrCreateOrderForTrade(orderId, timestamp, owner)
+  let order = orders.getOrCreateOrderForTrade(orderId, timestamp, ownerAddress)
 
   sellToken.save()
   buyToken.save()

--- a/src/modules/orders.ts
+++ b/src/modules/orders.ts
@@ -1,4 +1,4 @@
-import { log } from "@graphprotocol/graph-ts"
+import { Bytes, log } from "@graphprotocol/graph-ts"
 import { BigInt } from "@graphprotocol/graph-ts"
 import { Order } from "../../generated/schema"
 import { totals } from "./totals"
@@ -6,13 +6,13 @@ import { totals } from "./totals"
 
 export namespace orders {
 
-    export function invalidateOrder(orderId: string, timestamp: i32): Order {
+    export function invalidateOrder(orderId: Bytes, timestamp: i32): Order {
 
         let order = Order.load(orderId)
 
         if (!order) {
             order = new Order(orderId)
-            log.info('Order {} was not found. It was created for being invalidated', [orderId])
+            log.info('Order {} was not found. It was created for being invalidated', [orderId.toHexString()])
         }
 
         order.isValid = false
@@ -21,7 +21,7 @@ export namespace orders {
         return order as Order
     }
 
-    export function setPresignature(orderId: string, owner: string, timestamp: i32, signed: boolean): Order {
+    export function setPresignature(orderId: Bytes, owner: Bytes, timestamp: i32, signed: boolean): Order {
 
         // check if makes sense to count orders (in totals) that are coming from here
         let order = getOrCreateOrder(orderId, owner, timestamp)
@@ -32,7 +32,7 @@ export namespace orders {
         return order as Order
     }
 
-    export function getOrCreateOrderForTrade(orderId: string, timestamp: i32, owner: string): Order {
+    export function getOrCreateOrderForTrade(orderId: Bytes, timestamp: i32, owner: Bytes): Order {
 
         let order = getOrCreateOrder(orderId, owner, timestamp)
         order.tradesTimestamp = timestamp
@@ -40,7 +40,7 @@ export namespace orders {
         return order as Order
     }
 
-    function getOrCreateOrder(orderId: string, owner: string, timestamp: i32): Order {
+    function getOrCreateOrder(orderId: Bytes, owner: Bytes, timestamp: i32): Order {
 
         let order = Order.load(orderId)
 

--- a/src/modules/pairs.ts
+++ b/src/modules/pairs.ts
@@ -1,4 +1,4 @@
-import { BigInt, BigDecimal, Address } from "@graphprotocol/graph-ts";
+import { BigInt, BigDecimal, Address, Bytes } from "@graphprotocol/graph-ts";
 import { PairDaily, PairHourly, Pair } from "../../generated/schema";
 import { ZERO_BD, ZERO_BI } from "../utils/constants";
 import { getDayTotalTimestamp, getHourTotalTimestamp } from "../utils/timeframeTimestamp";
@@ -6,12 +6,12 @@ import { getDayTotalTimestamp, getHourTotalTimestamp } from "../utils/timeframeT
 export namespace pairs {
 
   export class TokenProps {
-    token: string
+    token: Bytes
     volume: BigInt
     price: BigDecimal | null
     relativePrice: BigDecimal
     constructor(
-      _token: string,
+      _token: Bytes,
       _volume: BigInt,
       _price: BigDecimal | null,
       _relativePrice: BigDecimal
@@ -23,7 +23,7 @@ export namespace pairs {
     }
   }
 
-  export function createOrUpdatePair(timestamp: i32, buyTokenId: string, sellTokenId: string, buyAmount: BigInt, sellAmount: BigInt,
+  export function createOrUpdatePair(timestamp: i32, buyTokenId: Bytes, sellTokenId: Bytes, buyAmount: BigInt, sellAmount: BigInt,
     sellAmountEth: BigDecimal | null, sellAmountUsd: BigDecimal | null, buyTokenPriceUsd: BigDecimal | null, sellTokenPriceUsd: BigDecimal | null,
     buyAmountDecimals: BigDecimal, sellAmountDecimals: BigDecimal): void {
     let canonicalMarket = getCanonicalMarket(buyTokenId, sellTokenId, buyAmount, sellAmount, buyTokenPriceUsd, sellTokenPriceUsd, buyAmountDecimals, sellAmountDecimals)
@@ -50,13 +50,11 @@ export namespace pairs {
       sellAmountEth, sellAmountUsd)
   }
 
-  function getCanonicalMarket(buyTokenId: string, sellTokenId: string, buyAmount: BigInt, sellAmount: BigInt,
+  function getCanonicalMarket(buyTokenId: Bytes, sellTokenId: Bytes, buyAmount: BigInt, sellAmount: BigInt,
     buyTokenPriceUsd: BigDecimal | null, sellTokenPriceUsd: BigDecimal | null,
     buyAmountDecimals: BigDecimal, sellAmountDecimals: BigDecimal): Map<string, TokenProps> {
-    let buyTokenAddress = Address.fromString(buyTokenId)
-    let sellTokenAddress = Address.fromString(sellTokenId)
-    let buyTokenNumber = BigInt.fromUnsignedBytes(buyTokenAddress)
-    let sellTokenNumber = BigInt.fromUnsignedBytes(sellTokenAddress)
+    let buyTokenNumber = BigInt.fromUnsignedBytes(buyTokenId)
+    let sellTokenNumber = BigInt.fromUnsignedBytes(sellTokenId)
     let value = new Map<string, TokenProps>()
 
     let buyTokenExpressedOnSellToken = ZERO_BD
@@ -144,8 +142,8 @@ export namespace pairs {
   }
 
 
-  function getOrCreatePair(token0: string, token1: string): Pair {
-    let id = token0 + "-" + token1
+  function getOrCreatePair(token0: Bytes, token1: Bytes): Pair {
+    let id = token0.toHexString() + "-" + token1.toHexString()
     let pairTotal = Pair.load(id)
 
     if (!pairTotal) {
@@ -161,9 +159,9 @@ export namespace pairs {
     return pairTotal as Pair
   }
 
-  function getOrCreatePairDaily(token0: string, token1: string, timestamp: i32): PairDaily {
+  function getOrCreatePairDaily(token0: Bytes, token1: Bytes, timestamp: i32): PairDaily {
     let dailyTimestamp = getDayTotalTimestamp(timestamp)
-    let id = token0 + "-" + token1 + "-" + dailyTimestamp.toString()
+    let id = token0.toHexString() + "-" + token1.toHexString() + "-" + dailyTimestamp.toString()
     let pairDailyTotal = PairDaily.load(id)
 
     if (!pairDailyTotal) {
@@ -181,9 +179,9 @@ export namespace pairs {
 
   }
 
-  function getOrCreatePairHourly(token0: string, token1: string, timestamp: i32): PairHourly {
+  function getOrCreatePairHourly(token0: Bytes, token1: Bytes, timestamp: i32): PairHourly {
     let hourlyTimestamp = getHourTotalTimestamp(timestamp)
-    let id = token0 + "-" + token1 + "-" + hourlyTimestamp.toString()
+    let id = token0.toHexString() + "-" + token1.toHexString() + "-" + hourlyTimestamp.toString()
     let pairHourlyTotal = PairHourly.load(id)
 
     if (!pairHourlyTotal) {

--- a/src/modules/settlements.ts
+++ b/src/modules/settlements.ts
@@ -7,7 +7,7 @@ import { getEthPriceInUSD } from "../utils/pricing"
 
 export namespace settlements {
 
-    export function getOrCreateSettlement(txHash: Bytes, tradeTimestamp: i32, solver: Address, txGasPrice: BigInt, feeAmountUsd: BigDecimal): void { 
+    export function getOrCreateSettlement(txHash: Bytes, tradeTimestamp: i32, solver: Address, txGasPrice: BigInt, feeAmountUsd: BigDecimal | null): void { 
 
         let settlementId = txHash.toHexString()
         let network = dataSource.network()
@@ -36,8 +36,10 @@ export namespace settlements {
             settlement.profitability = ZERO_BD
             totals.addSettlementCount(tradeTimestamp)
         } 
-        let prevFeeAmountUsd = settlement.aggregatedFeeAmountUsd
-        settlement.aggregatedFeeAmountUsd = prevFeeAmountUsd.plus(feeAmountUsd)
+        if(feeAmountUsd) {
+            let prevFeeAmountUsd = settlement.aggregatedFeeAmountUsd
+            settlement.aggregatedFeeAmountUsd = prevFeeAmountUsd.plus(feeAmountUsd)
+        }
         settlement.profitability = settlement.aggregatedFeeAmountUsd.minus(settlement.txCostUsd)
         settlement.save()
     }

--- a/src/modules/settlements.ts
+++ b/src/modules/settlements.ts
@@ -29,7 +29,7 @@ export namespace settlements {
             settlement = new Settlement(settlementId)
             settlement.txHash = txHash
             settlement.firstTradeTimestamp = tradeTimestamp
-            settlement.solver = solver.toHexString()
+            settlement.solver = solver
             settlement.txCostUsd = txCostUsd
             settlement.txCostNative = txCostNative
             settlement.aggregatedFeeAmountUsd = ZERO_BD

--- a/src/modules/tokens.ts
+++ b/src/modules/tokens.ts
@@ -1,4 +1,4 @@
-import { Address, BigDecimal, BigInt, dataSource } from "@graphprotocol/graph-ts"
+import { Address, BigDecimal, BigInt, Bytes, dataSource } from "@graphprotocol/graph-ts"
 import { ERC20 } from "../../generated/GPV2Settlement/ERC20"
 import { Token, TokenDailyTotal, TokenHourlyTotal, TokenTradingEvent } from "../../generated/schema"
 import { ZERO_BD, ZERO_BI, MINUS_ONE_BD, ONE_BI } from "../utils/constants"
@@ -11,14 +11,13 @@ let DEFAULT_DECIMALS = 18
 export namespace tokens {
 
   export function getOrCreateToken(tokenAddress: Address, timestamp: i32): Token {
-    let tokenId = tokenAddress.toHexString()
-    let token = Token.load(tokenId)
+    let token = Token.load(tokenAddress)
     let network = dataSource.network()
 
     // check if token exists
     if (!token) {
       // creates a new token and fill properites
-      token = new Token(tokenId)
+      token = new Token(tokenAddress)
       token.address = tokenAddress
       token.firstTradeTimestamp = timestamp ? timestamp : 0
 
@@ -70,8 +69,7 @@ export namespace tokens {
   }
 
   export function getTokenDecimals(tokenAddress: Address): number {
-    let tokenId = tokenAddress.toHexString()
-    let token = Token.load(tokenId)
+    let token = Token.load(tokenAddress)
 
     if (token) {
       return token.decimals
@@ -83,8 +81,8 @@ export namespace tokens {
     return tokenDecimals.reverted ? DEFAULT_DECIMALS : tokenDecimals.value
   }
 
-  export function createTokenTradingEvent(timestamp: i32, tokenId: string, tradeId: string, amount: BigInt, amountEth: BigDecimal | null, amountUsd: BigDecimal | null, tokenPrice: BigDecimal | null): void {
-    let id = tokenId + timestamp.toString()
+  export function createTokenTradingEvent(timestamp: i32, tokenId: Bytes, tradeId: string, amount: BigInt, amountEth: BigDecimal | null, amountUsd: BigDecimal | null, tokenPrice: BigDecimal | null): void {
+    let id = tokenId.toHexString() + timestamp.toString()
     let tradingEvent = new TokenTradingEvent(id)
     tradingEvent.token = tokenId
     tradingEvent.trade = tradeId
@@ -96,10 +94,10 @@ export namespace tokens {
     updateTokenHourlyTotal(timestamp, tokenId, amount, amountEth, amountUsd, tokenPrice)
   }
 
-  function getOrCreateTokenDailyTotal(tokenId: string, timestamp: i32): TokenDailyTotal {
+  function getOrCreateTokenDailyTotal(tokenId: Bytes, timestamp: i32): TokenDailyTotal {
 
     let dailyTimestamp = getDayTotalTimestamp(timestamp)
-    let dailyTimestampId = tokenId + "-" + dailyTimestamp.toString()
+    let dailyTimestampId = tokenId.toHexString() + "-" + dailyTimestamp.toString()
     let total = TokenDailyTotal.load(dailyTimestampId)
 
     if (!total) {
@@ -120,10 +118,10 @@ export namespace tokens {
     return total as TokenDailyTotal
   }
 
-  function getOrCreateTokenHourlyTotal(tokenId: string, timestamp: i32): TokenHourlyTotal {
+  function getOrCreateTokenHourlyTotal(tokenId: Bytes, timestamp: i32): TokenHourlyTotal {
 
     let hourlyTimestamp = getHourTotalTimestamp(timestamp)
-    let hourlyTimestampId = tokenId + "-" + hourlyTimestamp.toString()
+    let hourlyTimestampId = tokenId.toHexString() + "-" + hourlyTimestamp.toString()
     let total = TokenHourlyTotal.load(hourlyTimestampId)
 
     if (!total) {
@@ -144,7 +142,7 @@ export namespace tokens {
     return total as TokenHourlyTotal
   }
 
-  function updateTokenDailyTotal(timestamp: i32, tokenId: string, amount: BigInt, amountEth: BigDecimal | null, amountUsd: BigDecimal | null, tokenPrice: BigDecimal | null): void {
+  function updateTokenDailyTotal(timestamp: i32, tokenId: Bytes, amount: BigInt, amountEth: BigDecimal | null, amountUsd: BigDecimal | null, tokenPrice: BigDecimal | null): void {
 
     let total = getOrCreateTokenDailyTotal(tokenId, timestamp)
 
@@ -200,7 +198,7 @@ export namespace tokens {
     let denominator = prevVolumeBD.plus(currentVolumeBD)
     return numerator.div(denominator) as BigDecimal
   }
-  function updateTokenHourlyTotal(timestamp: i32, tokenId: string, amount: BigInt, amountEth: BigDecimal | null, amountUsd: BigDecimal | null, tokenPrice: BigDecimal | null): void {
+  function updateTokenHourlyTotal(timestamp: i32, tokenId: Bytes, amount: BigInt, amountEth: BigDecimal | null, amountUsd: BigDecimal | null, tokenPrice: BigDecimal | null): void {
 
     let total = getOrCreateTokenHourlyTotal(tokenId, timestamp)
 

--- a/src/modules/trades.ts
+++ b/src/modules/trades.ts
@@ -8,11 +8,11 @@ import { ZERO_ADDRESS, ZERO_BD, ZERO_BI } from "../utils/constants"
 export namespace trades {
 
     export function getOrCreateTrade(event: Trade, buyToken: Token, sellToken: Token): void {
-        let orderId = event.params.orderUid.toHexString()
+        let orderId = event.params.orderUid
         let eventIndex = event.transaction.index.toString()
         let txHash = event.transaction.hash
         let txHashString = txHash.toHexString()
-        let tradeId = orderId + "|" + txHashString + "|" + eventIndex
+        let tradeId = orderId.toHexString() + "|" + txHashString + "|" + eventIndex
         let timestamp = event.block.timestamp.toI32()
         let sellAmount = event.params.sellAmount
         let buyAmount = event.params.buyAmount
@@ -62,11 +62,11 @@ export namespace trades {
         trade.timestamp = timestamp ? timestamp : 0
         trade.txHash = txHash ? txHash : ZERO_ADDRESS
         trade.settlement = txHashString ? txHashString : ""
-        trade.buyToken = buyTokenId ? buyTokenId : ""
+        trade.buyToken = buyTokenId ? buyTokenId : ZERO_ADDRESS
         trade.buyAmount = buyAmount ? buyAmount : ZERO_BI
-        trade.sellToken = sellTokenId ? sellTokenId : ""
+        trade.sellToken = sellTokenId ? sellTokenId : ZERO_ADDRESS
         trade.sellAmount = sellAmount ? sellAmount : ZERO_BI
-        trade.order = orderId ? orderId : ""
+        trade.order = orderId ? orderId : ZERO_ADDRESS
         trade.gasPrice = txGasPrice ? txGasPrice : ZERO_BI
         trade.feeAmount = feeAmount ? feeAmount : ZERO_BI
         trade.feeAmountUsd = feeAmountUsd
@@ -87,7 +87,7 @@ export namespace trades {
             ethAmountForVolumes = buyAmountEth
         }
 
-        users.getOrCreateTrader(owner, timestamp, ownerAddress, ethAmountForVolumes, usdAmountForVolumes)
+        users.getOrCreateTrader(timestamp, ownerAddress, ethAmountForVolumes, usdAmountForVolumes)
         users.getOrCreateSolver(solver, ethAmountForVolumes, usdAmountForVolumes)
 
         totals.addVolumesAndFees(ethAmountForVolumes, usdAmountForVolumes, feeAmountEth, feeAmountUsd, timestamp)

--- a/src/modules/trades.ts
+++ b/src/modules/trades.ts
@@ -53,8 +53,8 @@ export namespace trades {
         let buyTokenId = buyToken.id
         let sellTokenId = sellToken.id
 
-        let buyTokenPriceUsd = buyToken.priceUsd as BigDecimal
-        let sellTokenPriceUsd = sellToken.priceUsd as BigDecimal
+        let buyTokenPriceUsd = _buyTokenPriceUsd ? _buyTokenPriceUsd as BigDecimal : null
+        let sellTokenPriceUsd = _sellTokenPriceUsd ? _sellTokenPriceUsd as BigDecimal : null
 
         tokens.createTokenTradingEvent(timestamp, buyTokenId, tradeId, buyAmount, buyAmountEth, buyAmountUsd, buyTokenPriceUsd)
         tokens.createTokenTradingEvent(timestamp, sellTokenId, tradeId, sellAmount, sellAmountEth, sellAmountUsd, sellTokenPriceUsd)

--- a/src/modules/users.ts
+++ b/src/modules/users.ts
@@ -1,14 +1,14 @@
-import { Address, BigDecimal, BigInt } from "@graphprotocol/graph-ts"
+import { Address, BigDecimal, Bytes } from "@graphprotocol/graph-ts"
 import { User } from "../../generated/schema"
 import { ZERO_BD } from "../utils/constants"
 import { totals } from "./totals"
 
 export namespace users {
 
-    function getOrCreateUserEntity(id: string, address: Address): User{
-        let user = User.load(id)
+    function getOrCreateUserEntity(address: Address): User{
+        let user = User.load(address)
         if (!user) {
-            user = new User(id)
+            user = new User(address)
             user.address = address
             user.isSolver = false
             user.numberOfTrades = 0
@@ -22,9 +22,9 @@ export namespace users {
         return user as User
     }
 
-   export function getOrCreateTrader(orderOwner: string, timestamp: i32, owner: Address, tradedAmountEth: BigDecimal | null, tradedAmountUsd: BigDecimal | null) :void {
+   export function getOrCreateTrader(timestamp: i32, owner: Address, tradedAmountEth: BigDecimal | null, tradedAmountUsd: BigDecimal | null) :void {
 
-        let user = getOrCreateUserEntity(orderOwner, owner)
+        let user = getOrCreateUserEntity(owner)
         let prevTradedAmountUsd = user.tradedAmountUsd
         let prevTradedAmountEth = user.tradedAmountEth
 
@@ -51,14 +51,14 @@ export namespace users {
         user.save()
     }
 
-    export function getOrCreateSigner(orderOwner: string, owner: Address) :void {
-        let user = getOrCreateUserEntity(orderOwner, owner)
+    export function getOrCreateSigner(owner: Address) :void {
+        let user = getOrCreateUserEntity(owner)
         user.save()
     }
 
     export function getOrCreateSolver(solver: Address, solvedAmountEth: BigDecimal | null, solvedAmountUsd: BigDecimal | null): void{
 
-        let user = getOrCreateUserEntity(solver.toHexString(), solver)
+        let user = getOrCreateUserEntity(solver)
         let prevNumOfTrades = user.numberOfTrades
         let prevSolvedAmountUsd = user.solvedAmountUsd
         let prevSolvedAmountEth = user.solvedAmountEth

--- a/src/uniswapMappings/uniswapPoolFactory.ts
+++ b/src/uniswapMappings/uniswapPoolFactory.ts
@@ -5,7 +5,7 @@ import { PoolCreated } from '../../generated/Factory/Factory'
 import { UniswapPool, UniswapToken, Bundle } from '../../generated/schema'
 import { Pool as PoolTemplate } from '../../generated/templates'
 import { fetchTokenSymbol, fetchTokenName, fetchTokenDecimals } from '../utils/token'
-import { log, Address } from '@graphprotocol/graph-ts'
+import { log, Address, Bytes } from '@graphprotocol/graph-ts'
 
 export function handlePoolCreated(event: PoolCreated): void {
   // temp fix
@@ -21,13 +21,13 @@ export function handlePoolCreated(event: PoolCreated): void {
     bundle.save()
   }
 
-  let pool = new UniswapPool(event.params.pool.toHexString()) as UniswapPool
-  let token0 = UniswapToken.load(event.params.token0.toHexString())
-  let token1 = UniswapToken.load(event.params.token1.toHexString())
+  let pool = new UniswapPool(event.params.pool) as UniswapPool
+  let token0 = UniswapToken.load(event.params.token0)
+  let token1 = UniswapToken.load(event.params.token1)
 
   // fetch info if null
   if (token0 === null) {
-    token0 = new UniswapToken(event.params.token0.toHexString())
+    token0 = new UniswapToken(event.params.token0)
     token0.address = event.params.token0
     token0.symbol = fetchTokenSymbol(event.params.token0)
     token0.name = fetchTokenName(event.params.token0)
@@ -42,11 +42,11 @@ export function handlePoolCreated(event: PoolCreated): void {
     token0.decimals = decimals.toI32()
     token0.priceEth = ZERO_BD
     token0.priceUsd = ZERO_BD
-    token0.allowedPools = new Array<string>(0)
+    token0.allowedPools = new Array<Bytes>(0)
   }
 
   if (token1 === null) {
-    token1 = new UniswapToken(event.params.token1.toHexString())
+    token1 = new UniswapToken(event.params.token1)
     token1.address = event.params.token1
     token1.symbol = fetchTokenSymbol(event.params.token1)
     token1.name = fetchTokenName(event.params.token1)
@@ -59,7 +59,7 @@ export function handlePoolCreated(event: PoolCreated): void {
     token1.decimals = decimals.toI32()
     token1.priceEth = ZERO_BD
     token1.priceUsd = ZERO_BD
-    token1.allowedPools = new Array<string>(0)
+    token1.allowedPools = new Array<Bytes>(0)
   }
 
   // update white listed pools

--- a/src/uniswapMappings/uniswapPools.ts
+++ b/src/uniswapMappings/uniswapPools.ts
@@ -1,6 +1,6 @@
 /* eslint-disable prefer-const */
 import { Bundle, UniswapPool, UniswapToken } from '../../generated/schema'
-import { BigDecimal, BigInt } from '@graphprotocol/graph-ts'
+import { BigDecimal, BigInt, Bytes } from '@graphprotocol/graph-ts'
 import {
   Burn as BurnEvent,
   Initialize,
@@ -12,7 +12,7 @@ import { ZERO_BD } from '../utils/constants'
 import { findEthPerToken, getEthPriceInUSD, sqrtPriceX96ToTokenPrices } from '../utils/pricing'
 
 export function handleInitialize(event: Initialize): void {
-  let pool = UniswapPool.load(event.address.toHexString())
+  let pool = UniswapPool.load(event.address)
   if (pool) {
     pool.tick = BigInt.fromI32(event.params.tick)
   }
@@ -45,7 +45,7 @@ export function handleInitialize(event: Initialize): void {
 }
 
 export function handleMint(event: MintEvent): void {
-  let poolAddress = event.address.toHexString()
+  let poolAddress = event.address
   let pool = UniswapPool.load(poolAddress)
 
   let token0Id = pool ? pool.token0 : null
@@ -94,7 +94,7 @@ export function handleMint(event: MintEvent): void {
 }
 
 export function handleBurn(event: BurnEvent): void {
-  let poolAddress = event.address.toHexString()
+  let poolAddress = event.address
   let pool = UniswapPool.load(poolAddress)
 
   let token0Id = pool ? pool.token0 : null
@@ -143,10 +143,10 @@ export function handleBurn(event: BurnEvent): void {
 
 export function handleSwap(event: SwapEvent): void {
   let bundle = Bundle.load('1')
-  let pool = UniswapPool.load(event.address.toHexString())
+  let pool = UniswapPool.load(event.address)
 
   // hot fix for bad pricing
-  if (pool && pool.id == '0x9663f2ca0454accad3e094448ea6f77443880454') {
+  if (pool && pool.id == Bytes.fromHexString('0x9663f2ca0454accad3e094448ea6f77443880454')) {
     return
   }
 

--- a/src/utils/getPrices.ts
+++ b/src/utils/getPrices.ts
@@ -44,9 +44,9 @@ function getUniswapPricesForPair(token0: Address, token1: Address, isEthPriceCal
     let reservesTry = pair.try_getReserves()
     let reserves = reservesTry.reverted ? EMPTY_RESERVES_RESULT : reservesTry.value
     let pairToken0Try = pair.try_token0()
-    let pairToken0 = pairToken0Try.reverted ? ZERO_ADDRESS as Address : pairToken0Try.value
+    let pairToken0 = pairToken0Try.reverted ? changetype<Address>(ZERO_ADDRESS) : pairToken0Try.value
     let pairToken1Try = pair.try_token1()
-    let pairToken1 = pairToken1Try.reverted ? ZERO_ADDRESS as Address : pairToken1Try.value
+    let pairToken1 = pairToken1Try.reverted ? changetype<Address>(ZERO_ADDRESS) : pairToken1Try.value
 
     if (reserves.value0 == ZERO_BI ||
         reserves.value1 == ZERO_BI ||

--- a/src/utils/pricing.ts
+++ b/src/utils/pricing.ts
@@ -1,46 +1,46 @@
 /* eslint-disable prefer-const */
 import { ONE_BD, ZERO_BD, ZERO_BI } from './constants'
 import { Bundle, UniswapPool, UniswapToken } from './../../generated/schema'
-import { BigDecimal, BigInt } from '@graphprotocol/graph-ts'
+import { BigDecimal, BigInt, Bytes } from '@graphprotocol/graph-ts'
 import { exponentToBigDecimal, safeDiv } from '../utils/index'
 
-const WETH_ADDRESS = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
-const USDC_WETH_03_POOL = '0x8ad599c3a0ff1de082011efddc58f1908eb6e6d8'
+const WETH_ADDRESS = Bytes.fromHexString('0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2')
+const USDC_WETH_03_POOL = Bytes.fromHexString('0x8ad599c3a0ff1de082011efddc58f1908eb6e6d8')
 
 // token where amounts should contribute to tracked volume and liquidity
 // usually tokens that many tokens are paired with s
 // next list and functions were taken from here: 
 // https://github.com/Uniswap/v3-subgraph/blob/bf03f940f17c3d32ee58bd37386f26713cff21e2/src/utils/pricing.ts#L12
-export let ALLOWED_TOKENS: string[] = [
+export let ALLOWED_TOKENS: Bytes[] = [
   WETH_ADDRESS, // WETH
-  '0x6b175474e89094c44da98b954eedeac495271d0f', // DAI
-  '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48', // USDC
-  '0xdac17f958d2ee523a2206206994597c13d831ec7', // USDT
-  '0x0000000000085d4780b73119b644ae5ecd22b376', // TUSD
-  '0x2260fac5e5542a773aa44fbcfedf7c193bc2c599', // WBTC
-  '0x5d3a536e4d6dbd6114cc1ead35777bab948e3643', // cDAI
-  '0x39aa39c021dfbae8fac545936693ac917d5e7563', // cUSDC
-  '0x86fadb80d8d2cff3c3680819e4da99c10232ba0f', // EBASE
-  '0x57ab1ec28d129707052df4df418d58a2d46d5f51', // sUSD
-  '0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2', // MKR
-  '0xc00e94cb662c3520282e6f5717214004a7f26888', // COMP
-  '0x514910771af9ca656af840dff83e8264ecf986ca', // LINK
-  '0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f', // SNX
-  '0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e', // YFI
-  '0x111111111117dc0aa78b770fa6a738034120c302', // 1INCH
-  '0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8', // yCurv
-  '0x956f47f50a910163d8bf957cf5846d573e7f87ca', // FEI
-  '0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0', // MATIC
-  '0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9' // AAVE
+  Bytes.fromHexString('0x6b175474e89094c44da98b954eedeac495271d0f'), // DAI
+  Bytes.fromHexString('0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'), // USDC
+  Bytes.fromHexString('0xdac17f958d2ee523a2206206994597c13d831ec7'), // USDT
+  Bytes.fromHexString('0x0000000000085d4780b73119b644ae5ecd22b376'), // TUSD
+  Bytes.fromHexString('0x2260fac5e5542a773aa44fbcfedf7c193bc2c599'), // WBTC
+  Bytes.fromHexString('0x5d3a536e4d6dbd6114cc1ead35777bab948e3643'), // cDAI
+  Bytes.fromHexString('0x39aa39c021dfbae8fac545936693ac917d5e7563'), // cUSDC
+  Bytes.fromHexString('0x86fadb80d8d2cff3c3680819e4da99c10232ba0f'), // EBASE
+  Bytes.fromHexString('0x57ab1ec28d129707052df4df418d58a2d46d5f51'), // sUSD
+  Bytes.fromHexString('0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2'), // MKR
+  Bytes.fromHexString('0xc00e94cb662c3520282e6f5717214004a7f26888'), // COMP
+  Bytes.fromHexString('0x514910771af9ca656af840dff83e8264ecf986ca'), // LINK
+  Bytes.fromHexString('0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f'), // SNX
+  Bytes.fromHexString('0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e'), // YFI
+  Bytes.fromHexString('0x111111111117dc0aa78b770fa6a738034120c302'), // 1INCH
+  Bytes.fromHexString('0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8'), // yCurv
+  Bytes.fromHexString('0x956f47f50a910163d8bf957cf5846d573e7f87ca'), // FEI
+  Bytes.fromHexString('0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0'), // MATIC
+  Bytes.fromHexString('0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9') // AAVE
 ]
 
-let STABLE_COINS: string[] = [
-  '0x6b175474e89094c44da98b954eedeac495271d0f',
-  '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
-  '0xdac17f958d2ee523a2206206994597c13d831ec7',
-  '0x0000000000085d4780b73119b644ae5ecd22b376',
-  '0x956f47f50a910163d8bf957cf5846d573e7f87ca',
-  '0x4dd28568d05f09b02220b09c2cb307bfd837cb95'
+let STABLE_COINS: Bytes[] = [
+  Bytes.fromHexString('0x6b175474e89094c44da98b954eedeac495271d0f'),
+  Bytes.fromHexString('0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'),
+  Bytes.fromHexString('0xdac17f958d2ee523a2206206994597c13d831ec7'),
+  Bytes.fromHexString('0x0000000000085d4780b73119b644ae5ecd22b376'),
+  Bytes.fromHexString('0x956f47f50a910163d8bf957cf5846d573e7f87ca'),
+  Bytes.fromHexString('0x4dd28568d05f09b02220b09c2cb307bfd837cb95')
 ]
 
 
@@ -61,7 +61,8 @@ export function sqrtPriceX96ToTokenPrices(sqrtPriceX96: BigInt, token0: UniswapT
 }
 
 export function getEthPriceInUSD(): BigDecimal {
-  let usdcPool = UniswapPool.load(USDC_WETH_03_POOL) // dai is token0
+  let USDC_WETH_03_POOL_ADDRESS = USDC_WETH_03_POOL
+  let usdcPool = UniswapPool.load(USDC_WETH_03_POOL_ADDRESS) // dai is token0
   if (usdcPool !== null) {
     return usdcPool.token0Price
   } else {


### PR DESCRIPTION
Based on this [article](https://medium.com/edge-node-engineering/two-simple-subgraph-performance-improvements-a76c6b3e7eac) from Edge & Node people I worked on this for improving the performance of our subgraph. 

This includes immutable entities and using Bytes as the id of entities. The two features are independent of each other; immutable entities only require a small change to the subgraph schema, while using byte strings as the id also requires small changes to the mappings.

Both of these enhancements will improve indexing speed, reduce the amount of data that needs to be stored for a subgraph, and also speed up some queries.

Due to the changes I already made I deployed this [here](https://thegraph.com/hosted-service/subgraph/gabrielcamba/cow-mocked) and tested the affected entities to check if the information is still right. The information seems to be ok. 

I need to perform an indexing speed test comparing it with the previous version. To perform this test I will remove a prop in both subgraphs (not crucial, just for making it index again) and I will query how many blocks are indexed in 10 minutes on different parts of the indexing progress for being able to decide if the change makes sense. Besides that, there should be improvements on some queries. 

Close #54 