### PR TITLE
Calculating txCost gasPrice * gasUsed

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -108,6 +108,7 @@ type Trade @entity {
   buyAmountUsd: BigDecimal
   "Sell amount in Usd"
   sellAmountUsd: BigDecimal
+  gasUsed: BigInt!
 }
 
 type Settlement @entity {

--- a/src/modules/settlements.ts
+++ b/src/modules/settlements.ts
@@ -7,7 +7,7 @@ import { getEthPriceInUSD } from "../utils/pricing"
 
 export namespace settlements {
 
-    export function getOrCreateSettlement(blockNumber: BigInt, txHash: Bytes, tradeTimestamp: i32, solver: Address, txGasPrice: BigInt, feeAmountUsd: BigDecimal | null): void { 
+    export function getOrCreateSettlement(blockNumber: BigInt, txHash: Bytes, tradeTimestamp: i32, solver: Address, txGasCost: BigInt, feeAmountUsd: BigDecimal | null): void { 
 
         let settlementId = txHash.toHexString()
         let network = dataSource.network()
@@ -16,7 +16,7 @@ export namespace settlements {
 
         let DEFAULT_DECIMALS =  BigInt.fromI32(18)
         let txCostUsd = ZERO_BD
-        let txCostNative = convertTokenToDecimal(txGasPrice, DEFAULT_DECIMALS)
+        let txCostNative = convertTokenToDecimal(txGasCost, DEFAULT_DECIMALS)
         if (network == 'xdai') {
             txCostUsd = txCostNative
         } else {

--- a/subgraph.yaml.mustache
+++ b/subgraph.yaml.mustache
@@ -15,7 +15,7 @@ dataSources:
       {{/startBlock}}
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.6
+      apiVersion: 0.0.7
       language: wasm/assemblyscript
       entities:
         - Trade
@@ -44,6 +44,7 @@ dataSources:
           handler: handleSettlement
         - event: Trade(indexed address,address,address,uint256,uint256,uint256,bytes)
           handler: handleTrade
+          receipt: true
       file: ./src/mapping.ts
 {{#uniV3Factory}}
   - kind: ethereum/contract
@@ -57,7 +58,7 @@ dataSources:
       {{/uniV3StartBlock}}
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.6
+      apiVersion: 0.0.7
       language: wasm/assemblyscript
       file: ./src/uniswapMappings/uniswapPoolFactory.ts
       entities:
@@ -85,7 +86,7 @@ templates:
       abi: Pool
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.6
+      apiVersion: 0.0.7
       language: wasm/assemblyscript
       file: ./src/uniswapMappings/uniswapPools.ts
       entities:


### PR DESCRIPTION
In the previous version txCost was showing the gasPrice.
This PR is fetching gasUsed from the txReceipt for being able to calculate the cost. 

This is being deployed [here](https://thegraph.com/hosted-service/subgraph/gabrielcamba/cow-one?version=pending)
please notice the version is still pending but you can query the subgraph with this:
``` GraphQL
{
  settlements{
    txCostNative
    txHash
  }
}
```
using etherscan.io check for that txHash txCostNative should be in "Transaction Fee" field.
there's also an estimation in usd you can find in txCostUSD prop.